### PR TITLE
chore: replace Coveralls badge with Codecov

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <p align=center>
   <a href="https://github.com/contributte/http/actions"><img src="https://badgen.net/github/checks/contributte/http/master?http=300"></a>
-  <a href="https://coveralls.io/r/contributte/http"><img src="https://badgen.net/coveralls/c/github/contributte/http?http=300"></a>
+  <a href="https://codecov.io/gh/contributte/http"><img src="https://badgen.net/codecov/c/github/contributte/http"></a>
   <a href="https://packagist.org/packages/contributte/http"><img src="https://badgen.net/packagist/dm/contributte/http"></a>
   <a href="https://packagist.org/packages/contributte/http"><img src="https://badgen.net/packagist/v/contributte/http"></a>
 </p>


### PR DESCRIPTION
## What changed
- replaced the remaining README coverage badge/link from Coveralls to Codecov
- verified the repository already uses the shared Codecov-based coverage workflow, so no workflow changes were needed

## Why
- completes the Coveralls-to-Codecov migration for this package
- keeps `contributte/http` aligned with the migration tracked in contributte/contributte#72