### PR TITLE
Remove phpdbg from coverage target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ tests:
 .PHONY: coverage
 coverage:
 ifdef GITHUB_ACTION
-	vendor/bin/tester -s -p phpdbg --colors 1 -C --coverage coverage.xml --coverage-src src tests/Cases
+	vendor/bin/tester -s -p php --colors 1 -C --coverage coverage.xml --coverage-src src tests/Cases
 else
-	vendor/bin/tester -s -p phpdbg --colors 1 -C --coverage coverage.html --coverage-src src tests/Cases
+	vendor/bin/tester -s -p php --colors 1 -C --coverage coverage.html --coverage-src src tests/Cases
 endif


### PR DESCRIPTION
## Summary

Replace `-p phpdbg` with `-p php` in the `coverage` Makefile target so coverage runs use the standard PHP binary.

## Motivation

This repository is part of the org-wide cleanup tracked in contributte/contributte#73.

## Changes

- switch both `coverage` target variants in `Makefile` from `phpdbg` to `php`

## Testing

- [ ] Tests pass locally
- [ ] CI passes
- [x] Manual verification

Manual verification notes:
- `make coverage` now invokes `vendor/bin/tester -s -p php ...`
- local coverage execution is blocked in this environment because PHP has no Xdebug or PCOV extension loaded, so tester exits with: `Code coverage functionality requires Xdebug or PCOV extension or PHPDBG SAPI (used php)`